### PR TITLE
Add TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,57 @@
+import * as React from 'react'
+
+export interface RequestProps {
+  cache: 'default' | 'reload' | 'no-cache'
+  credentials: 'omit' | 'same-origin' | 'include'
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
+  mode: 'cors' | 'no-cors' | 'same-origin' | 'navigate'
+  redirect: 'follow' | 'error' | 'manual'
+  referrer: 'client' | 'no-referrer' | string
+  referrerPolicy:
+    | 'no-referrer'
+    | 'no-referrer-when-downgrade'
+    | 'origin'
+    | 'origin-when-cross-origin'
+    | 'same-origin'
+    | 'strict-origin'
+    | 'strict-origin-when-cross-origin'
+    | 'unsafe-url'
+  url: string
+}
+
+export interface Request {
+  url: string
+  options?: Partial<RequestProps>
+}
+
+export interface FetchResult<TData> {
+  data?: TData
+  loading: boolean | null
+  error?: Error
+  request: Request
+}
+
+export type BodyMethods = 'arrayBuffer' | 'blob' | 'formData' | 'json' | 'text'
+
+export interface FetchProps<TData> {
+  url: string
+  options?: Partial<RequestProps> | (() => Partial<RequestProps>)
+  manual?: boolean
+  cache?: boolean | object
+  as?:
+    | 'auto'
+    | BodyMethods
+    | ((response) => void)
+    | { [type: string]: (res) => Promise<any> }
+  fetchFunction?: (url: string, options: object) => Promise<any>
+  onDataChange?: (newData, data) => any
+  onChange?: (result: FetchResult<TData>) => void
+  children: (result: FetchResult<TData>) => React.ReactNode | React.ReactNode
+}
+
+export default class Fetch<TData = any> extends React.Component<
+  FetchProps<TData>
+> {
+  // Passing any to FetchResult as unable to use TData
+  static Consumer: React.Consumer<FetchResult<any>>
+}

--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
       "<rootDir>/config/testSetup.js"
     ]
   },
-  "dependencies": {}
+  "dependencies": {},
+  "typings": "index.d.ts"
 }


### PR DESCRIPTION
Adding TypeScript typings 1. for type safety, 2. for code hinting in editors.

Able to use it as normal and `data` will come back as an `any` type.

Using TypeScript's JSX generics, `data` will be typed to the type you pass to it:
```tsx
interface IntlProps {
  someString: string
}

<Fetch<IntlProps> url={`/i18n/${locale}.json`}>
  {({ data }) => (
    <span>{data.someString}</span>
  )}
</Fetch>
```