### PR TITLE
Add TypeScript definitions to distributed NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": "techniq/react-fetch-component",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "main": "dist/index.js",
   "devDependencies": {


### PR DESCRIPTION
The TypeScript definitions aren't being bundled with the NPM package, so importing `react-fetch-component` into a TypeScript project doesn't properly surface typings. This PR adds the `index.d.ts` file to `package.json` so `npm pack` will bundle the typings file into the tarball properly.

Tested this on my fork and it appears to create the tarball as expected with the `index.d.ts` in the root where it should be.