### PR TITLE
Update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,41 +1,29 @@
 import * as React from 'react'
 
-export interface RequestProps {
-  cache: 'default' | 'reload' | 'no-cache'
-  credentials: 'omit' | 'same-origin' | 'include'
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
-  mode: 'cors' | 'no-cors' | 'same-origin' | 'navigate'
-  redirect: 'follow' | 'error' | 'manual'
-  referrer: 'client' | 'no-referrer' | string
-  referrerPolicy:
-    | 'no-referrer'
-    | 'no-referrer-when-downgrade'
-    | 'origin'
-    | 'origin-when-cross-origin'
-    | 'same-origin'
-    | 'strict-origin'
-    | 'strict-origin-when-cross-origin'
-    | 'unsafe-url'
+export interface FetchRequestProps {
   url: string
+  options?: RequestInit
 }
 
-export interface Request {
-  url: string
-  options?: Partial<RequestProps>
+export interface FetchUpdateOptions {
+  ignorePreviousData: boolean;
 }
 
 export interface FetchResult<TData> {
   data?: TData
   loading: boolean | null
   error?: Error
-  request: Request
+  request: FetchRequestProps
+  response: Response
+  fetch(url: string, options?: RequestInit, updateOptions?: Partial<FetchUpdateOptions>): void;
+  clearData(): void;
 }
 
 export type BodyMethods = 'arrayBuffer' | 'blob' | 'formData' | 'json' | 'text'
 
 export interface FetchProps<TData> {
   url: string
-  options?: Partial<RequestProps> | (() => Partial<RequestProps>)
+  options?: RequestInit | (() => RequestInit)
   manual?: boolean
   cache?: boolean | object
   as?:
@@ -43,7 +31,7 @@ export interface FetchProps<TData> {
     | BodyMethods
     | ((response: TData) => void)
     | { [type: string]: (res: TData) => Promise<any> }
-  fetchFunction?: (url: string, options: object) => Promise<any>
+  fetchFunction?: (url: string, options: RequestInit) => Promise<any>
   onDataChange?: (newData: TData, data: TData) => any
   onChange?: (result: FetchResult<TData>) => void
   children: (result: FetchResult<TData>) => React.ReactNode | React.ReactNode

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,10 +41,10 @@ export interface FetchProps<TData> {
   as?:
     | 'auto'
     | BodyMethods
-    | ((response) => void)
-    | { [type: string]: (res) => Promise<any> }
+    | ((response: TData) => void)
+    | { [type: string]: (res: TData) => Promise<any> }
   fetchFunction?: (url: string, options: object) => Promise<any>
-  onDataChange?: (newData, data) => any
+  onDataChange?: (newData: TData, data: TData) => any
   onChange?: (result: FetchResult<TData>) => void
   children: (result: FetchResult<TData>) => React.ReactNode | React.ReactNode
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": "techniq/react-fetch-component",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "main": "dist/index.js",
   "devDependencies": {


### PR DESCRIPTION
Merge after #18 and #19

Just updating the TypeScript definitions to:

- use the built-in fetch options from the ES6 definitions instead of a manually defined subset
- add `response`, `fetch`, and `clearData` props to the FetchResult object provided to children
- rename `Request` to `FetchRequestProps` to avoid namespace confusion

The result of these changes (#18, #19, #20) is published on NPM as a fork: [@lediur/react-fetch-component](https://www.npmjs.com/package/@lediur/react-fetch-component) if you want to test it out before merging.