### PR TITLE
Add "fetch" method to typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,8 @@ export default class Fetch<TData = any, TError = Error> extends React.Component<
     ) => React.ReactNode | React.ReactNode;
   }
 > {
+  fetch():void;
+  
   // Passing any to FetchResult as unable to use TData
   static Consumer: React.Consumer<FetchResult<any>>;
 }


### PR DESCRIPTION
It seems that this method was missing.